### PR TITLE
Update URL of the CNCF Platform Engineering Maturity Mode

### DIFF
--- a/data/quarantine/questions-de.yaml
+++ b/data/quarantine/questions-de.yaml
@@ -17,7 +17,7 @@ metadata:
     die Herausforderungen zu orientieren, denen sie begegnen könnten, und Chancen aufzuzeigen, die sie anstreben 
     können.</p>
     <p>Diese Bewertung basiert auf dem 
-    <a href="https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF Platform Engineering Reifegrad-Modell</a>, 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF Platform Engineering Reifegrad-Modell</a>, 
     das fünf Schlüsselaspekte bewertet: <strong>Investition</strong>, <strong>Adoption</strong>, <strong>Schnittstellen</strong>, 
     <strong>Betrieb</strong> und <strong>Messung</strong>.</p>
   results_title: "Bewertungsergebnisse"

--- a/data/quarantine/questions-es.yaml
+++ b/data/quarantine/questions-es.yaml
@@ -16,7 +16,7 @@ metadata:
     y observaciones en un modelo de madurez progresivo, buscamos orientar a los equipos de plataforma hacia los 
     desafíos que pueden enfrentar y las oportunidades que pueden perseguir.</p>
     <p>Esta evaluación se basa en el 
-    <a href="https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/" target="_blank">Modelo de Madurez de 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">Modelo de Madurez de 
     Ingeniería de Plataforma de CNCF</a>, 
     que evalúa cinco aspectos clave: <strong>Inversión</strong>, <strong>Adopción</strong>, <strong>Interfaces</strong>, 
     <strong>Operaciones</strong> y <strong>Medición</strong>.</p>

--- a/data/questions-en.yaml
+++ b/data/questions-en.yaml
@@ -13,7 +13,7 @@ metadata:
     for identifying opportunities for improvement in any organization. By organizing patterns and observations into a 
     progressive maturity model, we aim to orient platform teams to the challenges they may face and opportunities to aim for.</p>
     <p>This assessment is based on the 
-    <a href="https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF Platform Engineering Maturity Model</a>, 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF Platform Engineering Maturity Model</a>, 
     which evaluates five key aspects: <strong>Investment</strong>, <strong>Adoption</strong>, <strong>Interfaces</strong>, <strong>Operations</strong>, 
     nd <strong>Measurement</strong>.</p>
   results_title: Assessment Results

--- a/data/questions-pt.yaml
+++ b/data/questions-pt.yaml
@@ -13,7 +13,7 @@ metadata:
     oportunidades de melhoria em qualquer organização. Ao organizar padrões e observações em um modelo de maturidade progressivo, nosso objetivo é
     orientar as equipes de plataforma sobre os desafios que podem enfrentar e as oportunidades a serem buscadas.</p>
     <p>Esta avaliação é baseada no 
-    <a href="https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/" target="_blank">Modelo de Maturidade em Engenharia de Plataforma da CNCF</a>,
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">Modelo de Maturidade em Engenharia de Plataforma da CNCF</a>,
     que avalia cinco aspectos-chave: <strong>Investimento</strong>, <strong>Adoção</strong>, <strong>Interfaces de Usuário</strong>,
     <strong>Modelo Operacional</strong> e <strong>Métricas e Indicadores</strong>.</p><p>Estamos em busca de feedback sobre esta avaliação piloto, 
     então, por favor,

--- a/data/questions-zh.yaml
+++ b/data/questions-zh.yaml
@@ -10,7 +10,7 @@ metadata:
     <p>这个<span class="highlight">平台工程成熟度模型</span>为反思和识别任何组织的改进机会提供了一个框架。通过将模式和观察结果组织成渐进式成熟度模型，
     我们旨在为平台团队指明他们可能面临的挑战和可以追求的机会。</p>
     <p>此评估基于
-    <a href="https://tag-app-delivery.cncf.io/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF平台工程成熟度模型</a>, 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF平台工程成熟度模型</a>, 
     该模型评估五个关键方面：<strong>投入</strong>、<strong>采用</strong>、<strong>接口</strong>、<strong>运营</strong>和<strong>度量</strong>。</p>
     <p>我们正在征询对此次试点评估的反馈意见，请与我们
   results_title: 评估结果


### PR DESCRIPTION
This pull request updates the reference link to the CNCF Platform Engineering Maturity Model. The new link points to `cloudnativeplatforms.com` instead of `tag-app-delivery.cncf.io`.