### PR TITLE
Update framework and repo to prepare for 0.9.0 release

### DIFF
--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -1,0 +1,44 @@
+name: Validate content
+
+# Deliberately no `paths:` filter. This workflow is meant to become a required status
+# check on main, and a required check that gets skipped by a paths filter leaves the pull
+# request waiting on a run that will never report. It is fast enough to run every time.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-content:
+    name: validate-content
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # Full history so the version-bump gate can diff against the base branch
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install PyYAML
+        run: pip install --disable-pip-version-check pyyaml
+
+      - name: Validate assessment content
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ -n "$BASE_REF" ]; then
+            git fetch --no-tags origin "$BASE_REF"
+            python3 scripts/validate_content.py --base "origin/$BASE_REF"
+          else
+            python3 scripts/validate_content.py
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
-# Python — scripts/validate_content.py generates bytecode when imported
+# Python: scripts/validate_content.py generates bytecode when imported
 __pycache__/
 *.py[cod]
 .venv/
 venv/
 
-# Node — not used by the site itself, but contributors may install local tooling
+# Node: not used by the site itself, but contributors may install local tooling
 node_modules/
 npm-debug.log*
 
@@ -18,5 +18,5 @@ npm-debug.log*
 .DS_Store
 Thumbs.db
 
-# Local scratch — notes and drafts that are not part of the project
+# Local scratch: notes and drafts that are not part of the project
 .backlog/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Python — scripts/validate_content.py generates bytecode when imported
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# Node — not used by the site itself, but contributors may install local tooling
+node_modules/
+npm-debug.log*
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Local scratch — notes and drafts that are not part of the project
+.backlog/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ First tagged release. The assessment has been publicly available since July 2025
 
 ### Fixed
 
+- Answers were lost when switching language after arriving from a URL that already contained them — via the browser back button, a refresh, a bookmark, or a shared link. The language links were only rebuilt when state was written to the URL, never when it was read from it.
+- Switching language reset the assessment to the first page. The current page is now recorded in the URL as `page` and restored on load, clamped if the question set has since changed.
+- The browser back button did not step between assessment pages. Moving between pages now pushes a history entry, and back and forward rebuild the view from the URL. Answering a question still rewrites the current entry rather than adding one, so the back button is not consumed by individual radio clicks. Submitting also pushes an entry, so back leaves the results view instead of the site.
 - `README.md` listed the option scale as 1-5 (it is 1-4) and described Spanish as an available translation, when the live set is English, Japanese, Brazilian Portuguese and Chinese.
 
 ### Known issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+This project tracks two version numbers, explained in [VERSIONING.md](VERSIONING.md): the **release version** below, applied as a git tag, and the **content version** of the assessment question set, recorded in `data/questions-*.yaml`. Each release notes the content version it ships.
+
+## [Unreleased]
+
+## [0.9.0] - 2026-08-06
+
+Ships `content_version` **0.9.0**, tracking CNCF Platform Engineering Maturity Model **v1.0**.
+
+First tagged release. The assessment has been publicly available since July 2025; this release introduces version tracking rather than new functionality, so that future changes to the question set are visible and shareable links can be traced back to the content that produced them.
+
+### Added
+
+- `content_version` and `model_version` metadata in every content file, plus `model_url` linking to the exact upstream whitepaper release. Each translation points at its own locale of the whitepaper where that locale exists — Japanese, Chinese, Spanish and German do. Portuguese has no locale and uses the English original.
+- A version stamp (`v`) on shareable result URLs, so a shared link records which question set produced it. Bare visits are left unstamped.
+- Detection of stale shared links. A link built against an older question set is reported to the browser console; the user-facing notice follows in a later release. Answers are never discarded.
+- A page footer showing the assessment version and linking to the maturity model whitepaper it is based on.
+- `scripts/validate_content.py` and the `validate-content` GitHub Actions workflow — the repository's first CI. Blocks on structural drift between languages, malformed or missing version metadata, a mismatch between the intro link and `model_url`, and any change to the English question set that does not bump `content_version`.
+- [VERSIONING.md](VERSIONING.md) documenting the two-track scheme, the bump rules, and the release process.
+- This changelog.
+
+### Changed
+
+- Whitepaper links now point at the versioned `/v1/` URL rather than the unversioned canonical URL, so readers see the edition the questions were written against.
+- Whitepaper links carry campaign parameters, distinguishing the intro link from the footer link.
+- `loadStateFromURL()` now recognises a defined set of reserved query parameters instead of excluding `lang` and `view` individually — previously any unrecognised parameter was treated as an answer.
+
+### Fixed
+
+- `README.md` listed the option scale as 1-5 (it is 1-4) and described Spanish as an available translation, when the live set is English, Japanese, Brazilian Portuguese and Chinese.
+
+### Known issues
+
+The Japanese footer strings (`version_label`, `model_version_label`, `version_mismatch_notice`) were written as part of this release rather than by the translation's author, and would benefit from a native-speaker review.
+
+`.github/instructions/instructions.md` is substantially out of date — it documents a dynamic language-discovery system, a language `<select>` dropdown, and five functions that are not present in `assets/app.js`. It is left untouched by this release and tracked separately.
+
+Tracked for the `0.9.1` content patch:
+
+- The English intro reads `nd Measurement` instead of `and Measurement`.
+- The Chinese intro ends mid-sentence, with an unclosed tag and no feedback link.
+- The Chinese translation has no `page_indicator_text`, so pagination falls back to English.
+
+Not scheduled:
+
+- `data/quarantine/questions-es.yaml` is missing the fourth question of every category (15 of 20) and has a truncated intro. It is excluded from publication until it reaches parity.
+- `data/quarantine/questions-de.yaml` is at full structural parity but has not been reviewed for publication.
+
+## Prior to 0.9.0
+
+The assessment was developed between July 2025 and July 2026 across 84 commits and 9 merged pull requests, without tagged releases. This section summarises that work so the first release has a baseline to build on. It is grouped by theme rather than replayed commit by commit.
+
+### Assessment content and scoring model
+
+- Initial assessment tool (Jul 2025): 20 questions across five categories — Investment, Adoption, Interfaces, Operations, Measurement — each with four maturity levels.
+- Category score defined as the mean of answered questions in that category, rounded to two decimal places (#1, Aug 2025).
+- Question wording refinements: the Investment "who builds your platform" options widened to "team or group", and Adoption tool-selection gained a "compulsory platform" reading (#4, Sep 2025).
+- Title settled on "Platform Engineering Maturity Model Assessment", and the intro grew into an explainer of platform engineering and the five aspects.
+- All content — categories, questions, options, and every UI string — moved out of hand-written HTML into per-language YAML files under `data/` (#11, Sep–Oct 2025), making content edits and translation independent of markup.
+
+### Internationalization and translations
+
+- Chinese contributed as the first non-English language (#3, Sep 2025), initially as a separate `zh/index.html` page, together with the first language switcher.
+- Translation architecture reworked to a single `index.html` plus one `data/questions-<lang>.yaml` per language; the per-language HTML folders were deleted (#11, #13, Oct 2025).
+- Brazilian Portuguese translation added (#13, #16, Oct 2025), first as a separate page and then converted to the YAML pattern.
+- Japanese translation added (#18, Aug 2026), merged shortly before this release and brought up to the versioning conventions as part of it.
+- UI chrome made translatable through YAML `metadata` keys bound to `data-text` attributes: buttons, the page indicator, clipboard messages, and the feedback text.
+- Language links carry the current answer state, and from Oct 2025 keep you on the results view and re-render results in the newly selected language (#16).
+
+### User interface and navigation
+
+- Feedback affordances on the results panel: a "Share Feedback" link beside "Copy Shareable Link", plus a thank-you message block (#8, Sep 2025).
+- Multi-page wizard flow: one category per page with Previous / Next / Submit controls, a page indicator, and answers preserved between pages (#11, Sep–Oct 2025).
+- "Back to Assessment" control on the results view, and scroll-to-top on page change and submit.
+- Semantic HTML pass replacing generic `div`s with `main` / `article` / `header` / `nav`.
+
+### Results and visualization
+
+- Results present from the first commit: a canvas spider chart, a per-level heat-map matrix, and a per-category score list.
+- Layout moved from a two-column form-plus-sidebar grid to a single column with results below the form; results were later hidden until Submit as part of the wizard work.
+- Spider chart given two-line wrapping for long category labels, so longer translations stay legible (#13, Oct 2025).
+- Results view made addressable through a `view=results` parameter, so it can be shared directly and survives a language switch.
+
+### URL state and sharing
+
+- Answers encoded in the query string from the first commit, with a "Copy Shareable Link" button.
+- Share-link fix so links capture answers from every page of the wizard, not only the page on screen (Sep 2025).
+- `localStorage` persistence was introduced alongside pagination and then deliberately removed in favour of URL-only state (Oct 2025), leaving the URL as the single source of truth for answers, language, and view.
+
+### Styling
+
+- A CSS custom-property system was present from the start: colours, spacing scale, radii, font sizes, and the heat-map colour ramp.
+- CNCF restyle (Oct 2025): CNCF palette, Clarity City font stack, and a flat light background replacing the original gradient.
+- Migration to CSS logical properties (`margin-block-end`, `padding-block-end`).
+
+### Developer experience and tooling
+
+- Docker Compose and nginx local development environment mirroring the GitHub Pages path layout, documented in `README-docker.md` (#11, Sep 2025).
+- Repository layout tidied: CSS and JS moved into `assets/`, and asset paths changed from absolute to relative so the app works at any base path.
+- A substantial `app.js` refactor (Oct 2025) roughly halved the file.
+- GitHub issue templates for bug reports and feature requests (Aug 2025).
+- No test suite, build step, or CI existed before 0.9.0. The only runtime dependency is `js-yaml`, loaded from a CDN.
+
+### Added and later withdrawn
+
+Present in the history but deliberately **not** part of the shipped baseline:
+
+- **Spanish** — added Sep 2025, removed from the language navigation in Oct 2025 because the file did not contain the full question set, and moved to `data/quarantine/`. A Spanish-speaking contributor is still wanted.
+- **German** — added Oct 2025 as an explicit experiment in adding a language, never listed in the navigation, and moved to `data/quarantine/` as incomplete.
+- **Automatic language discovery** — a dropdown probing ~70 language codes was added in Oct 2025 and replaced three days later by a hardcoded list of links in `index.html`.
+- **Per-language HTML pages** and **nginx language redirects** — both removed during the YAML refactor in Oct 2025.
+
+### Contributors
+
+Steve Fenton, Corey McGalliard, Chris (Gentle) Yang, Eduardo Munari, Stéphane Di Cesare, Colin Griffin, Genki Matsuda, and Atulpriya Sharma.
+
+[Unreleased]: https://github.com/Cloud-Native-Platform-Engineering/pemm-assessment/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Cloud-Native-Platform-Engineering/pemm-assessment/releases/tag/v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,117 +8,44 @@ This project tracks two version numbers, explained in [VERSIONING.md](VERSIONING
 
 ## [0.9.0] - 2026-08-06
 
-Ships `content_version` **0.9.0**, tracking CNCF Platform Engineering Maturity Model **v1.0**.
-
-First tagged release. The assessment has been publicly available since July 2025; this release introduces version tracking rather than new functionality, so that future changes to the question set are visible and shareable links can be traced back to the content that produced them.
+First tagged release. Ships `content_version` **0.9.0**, tracking CNCF Platform Engineering Maturity Model **v1.0**.
 
 ### Added
 
-- `content_version` and `model_version` metadata in every content file, plus `model_url` linking to the exact upstream whitepaper release. Each translation points at its own locale of the whitepaper where that locale exists — Japanese, Chinese, Spanish and German do. Portuguese has no locale and uses the English original.
-- A version stamp (`v`) on shareable result URLs, so a shared link records which question set produced it. Bare visits are left unstamped.
-- Detection of stale shared links. A link built against an older question set is reported to the browser console; the user-facing notice follows in a later release. Answers are never discarded.
-- A page footer showing the assessment version and linking to the maturity model whitepaper it is based on.
-- `scripts/validate_content.py` and the `validate-content` GitHub Actions workflow — the repository's first CI. Blocks on structural drift between languages, malformed or missing version metadata, a mismatch between the intro link and `model_url`, and any change to the English question set that does not bump `content_version`.
-- [VERSIONING.md](VERSIONING.md) documenting the two-track scheme, the bump rules, and the release process.
+- Version metadata (`content_version`, `model_version`, `model_url`) in every content file.
+- Version stamp on shareable result URLs, so a link records which question set produced it.
+- Detection of links built against an older question set.
+- Page footer showing the assessment version and a link to the maturity model whitepaper.
+- Content validation in CI.
+- [VERSIONING.md](VERSIONING.md) describing the versioning scheme and release process.
 - This changelog.
 
 ### Changed
 
-- Whitepaper links now point at the versioned `/v1/` URL rather than the unversioned canonical URL, so readers see the edition the questions were written against.
-- Whitepaper links carry campaign parameters, distinguishing the intro link from the footer link.
-- `loadStateFromURL()` now recognises a defined set of reserved query parameters instead of excluding `lang` and `view` individually — previously any unrecognised parameter was treated as an answer.
+- Whitepaper links point at the versioned `/v1/` URL, localised per language where available.
+- Whitepaper links carry campaign parameters.
 
 ### Fixed
 
-- Answers were lost when switching language after arriving from a URL that already contained them — via the browser back button, a refresh, a bookmark, or a shared link. The language links were only rebuilt when state was written to the URL, never when it was read from it.
-- Switching language reset the assessment to the first page. The current page is now recorded in the URL as `page` and restored on load, clamped if the question set has since changed.
-- The browser back button did not step between assessment pages. Moving between pages now pushes a history entry, and back and forward rebuild the view from the URL. Answering a question still rewrites the current entry rather than adding one, so the back button is not consumed by individual radio clicks. Submitting also pushes an entry, so back leaves the results view instead of the site.
-- `README.md` listed the option scale as 1-5 (it is 1-4) and described Spanish as an available translation, when the live set is English, Japanese, Brazilian Portuguese and Chinese.
-
-### Known issues
-
-The Japanese footer strings (`version_label`, `model_version_label`, `version_mismatch_notice`) were written as part of this release rather than by the translation's author, and would benefit from a native-speaker review.
-
-`.github/instructions/instructions.md` is substantially out of date — it documents a dynamic language-discovery system, a language `<select>` dropdown, and five functions that are not present in `assets/app.js`. It is left untouched by this release and tracked separately.
-
-Tracked for the `0.9.1` content patch:
-
-- The English intro reads `nd Measurement` instead of `and Measurement`.
-- The Chinese intro ends mid-sentence, with an unclosed tag and no feedback link.
-- The Chinese translation has no `page_indicator_text`, so pagination falls back to English.
-
-Not scheduled:
-
-- `data/quarantine/questions-es.yaml` is missing the fourth question of every category (15 of 20) and has a truncated intro. It is excluded from publication until it reaches parity.
-- `data/quarantine/questions-de.yaml` is at full structural parity but has not been reviewed for publication.
+- Answers were lost when switching language after arriving from a URL that already contained them.
+- Switching language reset the assessment to the first page.
+- The browser back button did not step between assessment pages.
+- `README.md` listed the wrong option scale and language set.
 
 ## Prior to 0.9.0
 
-The assessment was developed between July 2025 and July 2026 across 84 commits and 9 merged pull requests, without tagged releases. This section summarises that work so the first release has a baseline to build on. It is grouped by theme rather than replayed commit by commit.
+Unversioned changes are summarised here so the first release has a baseline.
 
-### Assessment content and scoring model
-
-- Initial assessment tool (Jul 2025): 20 questions across five categories — Investment, Adoption, Interfaces, Operations, Measurement — each with four maturity levels.
-- Category score defined as the mean of answered questions in that category, rounded to two decimal places (#1, Aug 2025).
-- Question wording refinements: the Investment "who builds your platform" options widened to "team or group", and Adoption tool-selection gained a "compulsory platform" reading (#4, Sep 2025).
-- Title settled on "Platform Engineering Maturity Model Assessment", and the intro grew into an explainer of platform engineering and the five aspects.
-- All content — categories, questions, options, and every UI string — moved out of hand-written HTML into per-language YAML files under `data/` (#11, Sep–Oct 2025), making content edits and translation independent of markup.
-
-### Internationalization and translations
-
-- Chinese contributed as the first non-English language (#3, Sep 2025), initially as a separate `zh/index.html` page, together with the first language switcher.
-- Translation architecture reworked to a single `index.html` plus one `data/questions-<lang>.yaml` per language; the per-language HTML folders were deleted (#11, #13, Oct 2025).
-- Brazilian Portuguese translation added (#13, #16, Oct 2025), first as a separate page and then converted to the YAML pattern.
-- Japanese translation added (#18, Aug 2026), merged shortly before this release and brought up to the versioning conventions as part of it.
-- UI chrome made translatable through YAML `metadata` keys bound to `data-text` attributes: buttons, the page indicator, clipboard messages, and the feedback text.
-- Language links carry the current answer state, and from Oct 2025 keep you on the results view and re-render results in the newly selected language (#16).
-
-### User interface and navigation
-
-- Feedback affordances on the results panel: a "Share Feedback" link beside "Copy Shareable Link", plus a thank-you message block (#8, Sep 2025).
-- Multi-page wizard flow: one category per page with Previous / Next / Submit controls, a page indicator, and answers preserved between pages (#11, Sep–Oct 2025).
-- "Back to Assessment" control on the results view, and scroll-to-top on page change and submit.
-- Semantic HTML pass replacing generic `div`s with `main` / `article` / `header` / `nav`.
-
-### Results and visualization
-
-- Results present from the first commit: a canvas spider chart, a per-level heat-map matrix, and a per-category score list.
-- Layout moved from a two-column form-plus-sidebar grid to a single column with results below the form; results were later hidden until Submit as part of the wizard work.
-- Spider chart given two-line wrapping for long category labels, so longer translations stay legible (#13, Oct 2025).
-- Results view made addressable through a `view=results` parameter, so it can be shared directly and survives a language switch.
-
-### URL state and sharing
-
-- Answers encoded in the query string from the first commit, with a "Copy Shareable Link" button.
-- Share-link fix so links capture answers from every page of the wizard, not only the page on screen (Sep 2025).
-- `localStorage` persistence was introduced alongside pagination and then deliberately removed in favour of URL-only state (Oct 2025), leaving the URL as the single source of truth for answers, language, and view.
-
-### Styling
-
-- A CSS custom-property system was present from the start: colours, spacing scale, radii, font sizes, and the heat-map colour ramp.
-- CNCF restyle (Oct 2025): CNCF palette, Clarity City font stack, and a flat light background replacing the original gradient.
-- Migration to CSS logical properties (`margin-block-end`, `padding-block-end`).
-
-### Developer experience and tooling
-
-- Docker Compose and nginx local development environment mirroring the GitHub Pages path layout, documented in `README-docker.md` (#11, Sep 2025).
-- Repository layout tidied: CSS and JS moved into `assets/`, and asset paths changed from absolute to relative so the app works at any base path.
-- A substantial `app.js` refactor (Oct 2025) roughly halved the file.
-- GitHub issue templates for bug reports and feature requests (Aug 2025).
-- No test suite, build step, or CI existed before 0.9.0. The only runtime dependency is `js-yaml`, loaded from a CDN.
-
-### Added and later withdrawn
-
-Present in the history but deliberately **not** part of the shipped baseline:
-
-- **Spanish** — added Sep 2025, removed from the language navigation in Oct 2025 because the file did not contain the full question set, and moved to `data/quarantine/`. A Spanish-speaking contributor is still wanted.
-- **German** — added Oct 2025 as an explicit experiment in adding a language, never listed in the navigation, and moved to `data/quarantine/` as incomplete.
-- **Automatic language discovery** — a dropdown probing ~70 language codes was added in Oct 2025 and replaced three days later by a hardcoded list of links in `index.html`.
-- **Per-language HTML pages** and **nginx language redirects** — both removed during the YAML refactor in Oct 2025.
-
-### Contributors
-
-Steve Fenton, Corey McGalliard, Chris (Gentle) Yang, Eduardo Munari, Stéphane Di Cesare, Colin Griffin, Genki Matsuda, and Atulpriya Sharma.
+- Assessment of 20 questions across five categories (Investment, Adoption, Interfaces, Operations, Measurement)
+- All content moved out of hand-written HTML into per-language YAML files.
+- Translations added for Chinese, Brazilian Portuguese and Japanese.
+- Multi-page wizard flow, one category per page.
+- Results shown as a spider chart, heat-map matrix and per-category scores.
+- Assessment state held entirely in the URL, making results shareable.
+- CNCF styling and branding applied to the assessment.
+- Docker Compose development environment mirroring the GitHub Pages layout.
+- Spanish and German translations were added, then quarantined as incomplete.
+- An automatic language-discovery mechanism was added, then replaced by a fixed list of links.
 
 [Unreleased]: https://github.com/Cloud-Native-Platform-Engineering/pemm-assessment/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/Cloud-Native-Platform-Engineering/pemm-assessment/releases/tag/v0.9.0

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Note: If you switch the language while viewing the results, the app will keep yo
 
 ## Versioning
 
-The assessment question set carries its own version, separate from the repository's release tags, because the `field_name` keys and option values in shareable links are a public contract — renaming or renumbering a question silently changes what previously shared links mean.
+The assessment question set carries its own version, separate from the repository's release tags, because the `field_name` keys and option values in shareable links are a public contract: renaming or renumbering a question silently changes what previously shared links mean.
 
 Shareable links therefore include a `v` parameter recording the question set they were built against, and the footer shows the current assessment version alongside the CNCF Platform Engineering Maturity Model release it is based on.
 
-Before changing anything under `data/`, read [VERSIONING.md](VERSIONING.md) — it has the bump rules and the release process. You can check your changes locally with:
+Before changing anything under `data/`, read [VERSIONING.md](VERSIONING.md), which has the bump rules and the release process. You can check your changes locally with:
 
 ```sh
 python3 scripts/validate_content.py

--- a/README.md
+++ b/README.md
@@ -14,18 +14,33 @@ Note: If you switch the language while viewing the results, the app will keep yo
 
 <img width="1076" height="1201" alt="A screenshot showing the assessment results, a spider chart, heatmap matrix, and list of scores" src="https://github.com/user-attachments/assets/18d4b7db-1f52-4458-8970-acfbdf20c987" />
 
+## Versioning
+
+The assessment question set carries its own version, separate from the repository's release tags, because the `field_name` keys and option values in shareable links are a public contract — renaming or renumbering a question silently changes what previously shared links mean.
+
+Shareable links therefore include a `v` parameter recording the question set they were built against, and the footer shows the current assessment version alongside the CNCF Platform Engineering Maturity Model release it is based on.
+
+Before changing anything under `data/`, read [VERSIONING.md](VERSIONING.md) — it has the bump rules and the release process. You can check your changes locally with:
+
+```sh
+python3 scripts/validate_content.py
+```
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.
+
 ## Discussion
 
 Please join the [Cloud Native Computing Foundation on Slack](https://communityinviter.com/apps/cloud-native/cncf) and use the [platform-engineering](https://cloud-native.slack.com/archives/C020RHD43BP) channel.
 
 ## Content Management and Translations
 
-The assessment content is now managed through YAML files in the `/data/` directory for easy updates and translations:
+The assessment content is managed through YAML files in the `/data/` directory for easy updates and translations:
 
-- `questions-en.yaml` - English (default language)
-- `questions-[lang].yaml` - Translations
+- `questions-en.yaml` - English (source of truth)
+- `questions-[lang].yaml` - Translations, currently `ja`, `pt` and `zh`
+- `quarantine/` - Translations that are incomplete or not yet reviewed, excluded from the site
 
-To add a language, add the YAML file and add the language to the list in `index.html`.
+To add a language, add the YAML file and add a link for it to the language nav in `index.html`.
 
 ### Updating Questions and Content
 
@@ -33,10 +48,11 @@ To add a language, add the YAML file and add the language to the list in `index.
 
 1. **Make changes to the English source file first**: Edit `data/questions-en.yaml`
 2. **Update translation**: Apply equivalent changes to `data/questions-[lang].yaml`
-3. **Verify consistency**: Ensure all three files have:
+3. **Bump the version**: Follow the rules in [VERSIONING.md](VERSIONING.md)
+4. **Verify consistency**: Run `python3 scripts/validate_content.py`, which checks that every file has:
    - Same category IDs and structure
    - Same question IDs within each category
-   - Same option values (1-5) for scoring consistency
+   - Same option values (1-4) for scoring consistency
    - Translated text for all user-facing content
 
 ### What Needs Translation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ This repo contains the Platform Maturity Model Assessment.
 
 On answering the questions you get a spider diagram and a matrix to indicate where you are on a map right now.
 
-You can copy the URL to share the form in its current state, for example [this pre-filled form](https://cloud-native-platform-engineering.github.io/pemm-assessment/?investment_1=1&investment_2=1&investment_3=2&investment_4=1&adoption_1=1&adoption_2=2&adoption_3=2&adoption_4=2&interfaces_1=2&interfaces_2=3&interfaces_3=3&interfaces_4=4&operations_1=3&operations_2=3&operations_3=2&operations_4=1&measurement_1=3&measurement_2=4&measurement_3=4&measurement_4=4)
+You can copy the URL to share the assessment in whatever state it is in. For example:
+
+- [a completed assessment, opened on its results](https://cloud-native-platform-engineering.github.io/pemm-assessment/?investment_1=1&investment_2=1&investment_3=2&investment_4=1&adoption_1=1&adoption_2=2&adoption_3=2&adoption_4=2&interfaces_1=2&interfaces_2=3&interfaces_3=3&interfaces_4=4&operations_1=3&operations_2=3&operations_3=2&operations_4=1&measurement_1=3&measurement_2=4&measurement_3=4&measurement_4=4&v=0.9.0&view=results)
+- [a partly answered assessment, reopened on page 2](https://cloud-native-platform-engineering.github.io/pemm-assessment/?investment_1=2&investment_2=3&adoption_1=4&v=0.9.0&page=2)
+
+Alongside the answers, `v` records which version of the question set they were given against, `page` records which page was open, and `view=results` opens straight to the results.
 
 When [giving feedback](https://docs.google.com/forms/d/1SW8NE-7E2zjhoun4jklRPmH5sYgJ_3rTw2D_FoOwViA/viewform) please use these shareable URLs to help folks see what you see.
 
@@ -53,7 +58,8 @@ To add a language, add the YAML file and add a link for it to the language nav i
    - Same category IDs and structure
    - Same question IDs within each category
    - Same option values (1-4) for scoring consistency
-   - Translated text for all user-facing content
+
+   It compares structure only, and cannot tell whether the text was actually translated. Check that by eye.
 
 ### What Needs Translation
 
@@ -68,7 +74,7 @@ When updating content, ensure these elements are translated in all language file
 
 After updating translations:
 
-1. Test each language using URL parameters: `?lang=en`, `?lang=zh`, `?lang=es`
+1. Test each language using URL parameters: `?lang=en`, `?lang=ja`, `?lang=pt`, `?lang=zh`
 2. Verify all text displays correctly
 3. Ensure functionality works across all languages
 4. Test the complete assessment flow in each language

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -33,10 +33,6 @@ The tiers are defined by what happens to links that were shared before the chang
 | **MINOR** | Add a question with a new `field_name`, adjust scoring | Old links remain valid but **incomplete** |
 | **PATCH** | Reword a question, option, or description; fix a typo, translation, or link | Old links remain **fully valid** |
 
-Anything that alters `field_name` values, option `value` numbers, or the set of categories is at least MINOR. Text-only edits are PATCH.
-
-The app warns the visitor on MAJOR and MINOR mismatches, and stays silent on PATCH, because after a wording fix the answers still mean exactly what they meant before.
-
 `data/questions-en.yaml` is the source of truth. Bump it there first, then bring the translations up to the same number as they are updated.
 
 ## `model_version` and `model_url`

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,110 @@
+# Versioning
+
+This project tracks **two independent version numbers**. Knowing which one to change is usually the only thing you need from this document.
+
+| Version | Where it lives | What it describes |
+| --- | --- | --- |
+| **Release version** | git tag, e.g. `v0.9.0`, plus [CHANGELOG.md](CHANGELOG.md) | The repository as a whole — application code, styling, docs, content |
+| **Content version** | `metadata.content_version` in every `data/questions-*.yaml` | The assessment question set itself |
+
+They are allowed to differ, and usually will.
+
+## Why the content is versioned separately
+
+Answers are serialized straight into the URL:
+
+```text
+?investment_1=1&adoption_2=2&interfaces_3=3&v=0.9.0
+```
+
+Those `field_name` keys and their `1`–`4` values are a **public contract**. The README encourages people to share these links, and they turn up in screenshots, blog posts and conference slides.
+
+If a question is renamed, removed, or renumbered, every previously shared link silently starts meaning something different. No error, no warning — the same URL just produces a different result. That is a compatibility surface the application code does not have: a fix to the spider chart cannot invalidate anyone's saved link, but adding one question can.
+
+So the question set gets a version of its own, stamped into every shared link as `v`, and the app compares that stamp against the version it is running.
+
+## When to bump `content_version`
+
+The tiers are defined by what happens to links that were shared before the change.
+
+| Bump | Change | Effect on existing shared links |
+| --- | --- | --- |
+| **MAJOR** | Remove or rename a `field_name`; change the option `value` scale; remove a category | Old links now mean something **different** — actively misleading |
+| **MINOR** | Add a question or category with a new `field_name` | Old links remain valid but **incomplete** |
+| **PATCH** | Reword a question, option, or description; fix a typo, translation, or link | Old links remain **fully valid** |
+
+Anything that alters `field_name` values, option `value` numbers, or the set of categories is at least MINOR. Text-only edits are PATCH.
+
+The app warns the visitor on MAJOR and MINOR mismatches, and stays silent on PATCH — because after a wording fix the answers still mean exactly what they meant before.
+
+`data/questions-en.yaml` is the source of truth. Bump it there first, then bring the translations up to the same number as they are updated.
+
+## `model_version` and `model_url`
+
+`model_version` records which release of the upstream [CNCF Platform Engineering Maturity Model](https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/) the questions are derived from. `model_url` is the link to exactly that version.
+
+They sit next to each other deliberately. The whitepaper URL also appears inside the translated `intro` prose, and CI checks that both point at the same document — otherwise it is easy to bump `model_version` to `2.0` while the intro quietly keeps sending readers to v1.
+
+### Linking a translated whitepaper
+
+The whitepaper itself is published in several languages. A translation **should** point at its own locale rather than the English original — a reader working through the assessment in Japanese is better served by the Japanese source material.
+
+```yaml
+# data/questions-ja.yaml
+model_version: "1.0"
+model_url: "https://cloudnativeplatforms.com/ja/whitepapers/platform-eng-maturity-model/v1/?..."
+```
+
+Two rules apply:
+
+- `model_version` **must** be identical across every language. They all describe the same upstream release, and CI blocks a mismatch.
+- `model_url` **may** differ per language, but must point at the same release, and must agree with the whitepaper link inside that file's own `intro`.
+
+**Use the locale whenever it exists, even if that page is not translated yet.** The whitepaper site handles this itself: a locale that exists but has no translation for a given page renders a "Translation Needed" banner above the English text, with a link explaining how to contribute. Linking it keeps the reader in their own language context, tells them the truth, and starts serving the translation automatically the moment one lands — with no change needed here.
+
+So the test is whether the **locale** exists, not whether that particular page has been translated:
+
+```sh
+curl -o /dev/null -w '%{http_code}\n' -L \
+  https://cloudnativeplatforms.com/<lang>/whitepapers/platform-eng-maturity-model/v1/
+```
+
+`200` — use it. `404` — the locale does not exist at all, so use the English URL. Portuguese is currently in this position.
+
+## Translations
+
+Every language file carries the same `content_version` as `data/questions-en.yaml` once it is in sync. A file still showing an older number is, by definition, behind — CI reports this as a warning rather than an error, because a lagging translation is acceptable while a broken one is not.
+
+What is **not** optional is structural parity. Every published language must have identical category ids and order, question ids, `field_name` values, and option values. A translation that renames a field breaks scoring and shared links for everyone using that language. CI blocks on this.
+
+Files under `data/quarantine/` are excluded from publication and never block CI. A file lives there when it is incomplete or unreviewed. To bring one out: reach full structural parity, set its `content_version` to match the source, and move it into `data/`.
+
+## Cutting a release
+
+`main` is protected and requires pull requests, so releases are never tagged from a local branch.
+
+1. Branch, and make the change.
+2. Bump `content_version` if the question set changed. Add a `CHANGELOG.md` entry under `## [Unreleased]`.
+3. Open a pull request. The `validate-content` check must pass.
+4. Merge.
+5. Move the `## [Unreleased]` entries under a new version heading with the date.
+6. Tag the merge commit on `main` (`git tag v0.9.1`) and publish a GitHub Release pointing at that entry.
+
+There is no build step and no artifact — GitHub Pages serves `main` directly — so a tag is a marker of a known-good state rather than something that produces a deliverable.
+
+## What CI enforces
+
+`.github/workflows/validate-content.yml` runs `scripts/validate_content.py` on every pull request. Run it locally the same way:
+
+```sh
+python3 scripts/validate_content.py                    # structural checks
+python3 scripts/validate_content.py --base origin/main # also the version-bump gate
+```
+
+**Blocking:** files parse as YAML; every published language is at structural parity with the source; `content_version`, `model_version` and `model_url` are present and well formed; the intro whitepaper link agrees with `model_url`; and `data/questions-en.yaml` cannot change without its `content_version` changing too.
+
+**Warning only:** a translation behind the source version, and anything wrong in `data/quarantine/`.
+
+## Deliberate non-decisions
+
+**Conventional Commits are not used.** Their main payoff is deriving versions and changelogs automatically, and this project bumps versions by hand on purpose — there is no Node toolchain and no build step to hang that automation from. The version contract is stated explicitly in the data and enforced by CI, which is stronger than inferring intent from a commit prefix. If automated releases are ever adopted, adopt Conventional Commits at the same time, with `commitlint` in CI so the convention is enforced rather than aspirational.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -4,7 +4,7 @@ This project tracks **two independent version numbers**. Knowing which one to ch
 
 | Version | Where it lives | What it describes |
 | --- | --- | --- |
-| **Release version** | git tag, e.g. `v0.9.0`, plus [CHANGELOG.md](CHANGELOG.md) | The repository as a whole — application code, styling, docs, content |
+| **Release version** | git tag, e.g. `v0.9.0`, plus [CHANGELOG.md](CHANGELOG.md) | The repository as a whole: application code, styling, docs, content |
 | **Content version** | `metadata.content_version` in every `data/questions-*.yaml` | The assessment question set itself |
 
 They are allowed to differ, and usually will.
@@ -17,9 +17,9 @@ Answers are serialized straight into the URL:
 ?investment_1=1&adoption_2=2&interfaces_3=3&v=0.9.0
 ```
 
-Those `field_name` keys and their `1`–`4` values are a **public contract**. The README encourages people to share these links, and they turn up in screenshots, blog posts and conference slides.
+Those `field_name` keys and their `1` to `4` values are a **public contract**. The README encourages people to share these links, and they turn up in screenshots, blog posts and conference slides.
 
-If a question is renamed, removed, or renumbered, every previously shared link silently starts meaning something different. No error, no warning — the same URL just produces a different result. That is a compatibility surface the application code does not have: a fix to the spider chart cannot invalidate anyone's saved link, but adding one question can.
+If a question is renamed, removed, or renumbered, every previously shared link silently starts meaning something different. No error, no warning; the same URL just produces a different result. That is a compatibility surface the application code does not have: a fix to the spider chart cannot invalidate anyone's saved link, but adding one question can.
 
 So the question set gets a version of its own, stamped into every shared link as `v`, and the app compares that stamp against the version it is running.
 
@@ -29,13 +29,13 @@ The tiers are defined by what happens to links that were shared before the chang
 
 | Bump | Change | Effect on existing shared links |
 | --- | --- | --- |
-| **MAJOR** | Remove or rename a `field_name`; change the option `value` scale; remove a category | Old links now mean something **different** — actively misleading |
-| **MINOR** | Add a question or category with a new `field_name` | Old links remain valid but **incomplete** |
+| **MAJOR** | Remove or rename a `field_name`; change the option `value` scale; add or remove a category | Old links now mean something **different**, and are actively misleading |
+| **MINOR** | Add a question with a new `field_name`, adjust scoring | Old links remain valid but **incomplete** |
 | **PATCH** | Reword a question, option, or description; fix a typo, translation, or link | Old links remain **fully valid** |
 
 Anything that alters `field_name` values, option `value` numbers, or the set of categories is at least MINOR. Text-only edits are PATCH.
 
-The app warns the visitor on MAJOR and MINOR mismatches, and stays silent on PATCH — because after a wording fix the answers still mean exactly what they meant before.
+The app warns the visitor on MAJOR and MINOR mismatches, and stays silent on PATCH, because after a wording fix the answers still mean exactly what they meant before.
 
 `data/questions-en.yaml` is the source of truth. Bump it there first, then bring the translations up to the same number as they are updated.
 
@@ -43,11 +43,11 @@ The app warns the visitor on MAJOR and MINOR mismatches, and stays silent on PAT
 
 `model_version` records which release of the upstream [CNCF Platform Engineering Maturity Model](https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/) the questions are derived from. `model_url` is the link to exactly that version.
 
-They sit next to each other deliberately. The whitepaper URL also appears inside the translated `intro` prose, and CI checks that both point at the same document — otherwise it is easy to bump `model_version` to `2.0` while the intro quietly keeps sending readers to v1.
+They sit next to each other deliberately. The whitepaper URL also appears inside the translated `intro` prose, and CI checks that both point at the same document. Otherwise it is easy to bump `model_version` to `2.0` while the intro quietly keeps sending readers to v1.
 
-### Linking a translated whitepaper
+### Linking a translated maturity model
 
-The whitepaper itself is published in several languages. A translation **should** point at its own locale rather than the English original — a reader working through the assessment in Japanese is better served by the Japanese source material.
+The maturity model and whitepapers are published in several languages. A translation **should** point at its own locale rather than the English original. For example, a reader working through the assessment in Japanese is better served by the Japanese source material.
 
 ```yaml
 # data/questions-ja.yaml
@@ -60,7 +60,7 @@ Two rules apply:
 - `model_version` **must** be identical across every language. They all describe the same upstream release, and CI blocks a mismatch.
 - `model_url` **may** differ per language, but must point at the same release, and must agree with the whitepaper link inside that file's own `intro`.
 
-**Use the locale whenever it exists, even if that page is not translated yet.** The whitepaper site handles this itself: a locale that exists but has no translation for a given page renders a "Translation Needed" banner above the English text, with a link explaining how to contribute. Linking it keeps the reader in their own language context, tells them the truth, and starts serving the translation automatically the moment one lands — with no change needed here.
+**Use the locale whenever it exists, even if that page is not translated yet.** The whitepaper site handles this itself: a locale that exists but has no translation for a given page renders a "Translation Needed" banner above the English text, with a link explaining how to contribute. Linking it keeps the reader in their own language context, tells them the truth, and starts serving the translation automatically the moment one lands, with no change needed here.
 
 So the test is whether the **locale** exists, not whether that particular page has been translated:
 
@@ -69,11 +69,11 @@ curl -o /dev/null -w '%{http_code}\n' -L \
   https://cloudnativeplatforms.com/<lang>/whitepapers/platform-eng-maturity-model/v1/
 ```
 
-`200` — use it. `404` — the locale does not exist at all, so use the English URL. Portuguese is currently in this position.
+`200` means use it. `404` means the locale does not exist at all, so use the English URL. Portuguese is currently in this position.
 
 ## Translations
 
-Every language file carries the same `content_version` as `data/questions-en.yaml` once it is in sync. A file still showing an older number is, by definition, behind — CI reports this as a warning rather than an error, because a lagging translation is acceptable while a broken one is not.
+Every language file carries the same `content_version` as `data/questions-en.yaml` once it is in sync. A file still showing an older number is, by definition, behind. CI reports this as a warning rather than an error, because a lagging translation is acceptable while a broken one is not.
 
 What is **not** optional is structural parity. Every published language must have identical category ids and order, question ids, `field_name` values, and option values. A translation that renames a field breaks scoring and shared links for everyone using that language. CI blocks on this.
 
@@ -90,7 +90,7 @@ Files under `data/quarantine/` are excluded from publication and never block CI.
 5. Move the `## [Unreleased]` entries under a new version heading with the date.
 6. Tag the merge commit on `main` (`git tag v0.9.1`) and publish a GitHub Release pointing at that entry.
 
-There is no build step and no artifact — GitHub Pages serves `main` directly — so a tag is a marker of a known-good state rather than something that produces a deliverable.
+There is no build step and no artifact (GitHub Pages serves `main` directly), so a tag is a marker of a known-good state rather than something that produces a deliverable.
 
 ## What CI enforces
 
@@ -104,7 +104,3 @@ python3 scripts/validate_content.py --base origin/main # also the version-bump g
 **Blocking:** files parse as YAML; every published language is at structural parity with the source; `content_version`, `model_version` and `model_url` are present and well formed; the intro whitepaper link agrees with `model_url`; and `data/questions-en.yaml` cannot change without its `content_version` changing too.
 
 **Warning only:** a translation behind the source version, and anything wrong in `data/quarantine/`.
-
-## Deliberate non-decisions
-
-**Conventional Commits are not used.** Their main payoff is deriving versions and changelogs automatically, and this project bumps versions by hand on purpose — there is no Node toolchain and no build step to hang that automation from. The version contract is stated explicitly in the data and enforced by CI, which is stronger than inferring intent from a commit prefix. If automated releases are ever adopted, adopt Conventional Commits at the same time, with `commitlint` in CI so the convention is enforced rather than aspirational.

--- a/assets/app.js
+++ b/assets/app.js
@@ -44,6 +44,93 @@ let answerState = {};
     }
   }
 
+  // Query-string key holding the content version a shareable link was built against.
+  const VERSION_PARAM = 'v';
+
+  // Params that are not answers. Anything else in the query string is treated as one,
+  // so every non-answer param must be listed here.
+  const RESERVED_PARAMS = new Set(['lang', 'view', VERSION_PARAM]);
+
+  // Version of the question set currently loaded, or null if data failed to load.
+  function getContentVersion() {
+    return questionsData?.metadata?.content_version || null;
+  }
+
+  function parseVersion(version) {
+    const match = String(version ?? '').trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+    return match
+      ? { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) }
+      : null;
+  }
+
+  // A link is stale when the question set has gained, lost or renamed questions since it
+  // was shared -- major and minor bumps. Patch bumps are wording-only, so the answers
+  // still mean the same thing and there is nothing worth interrupting the user about.
+  // Unparseable versions are ignored rather than guessed at.
+  function isVersionMismatch(linkVersion, currentVersion) {
+    const link = parseVersion(linkVersion);
+    const current = parseVersion(currentVersion);
+
+    if (!link || !current) return false;
+
+    return link.major !== current.major || link.minor !== current.minor;
+  }
+
+  // The user-facing notice element lands in a follow-up PR. Toggling it here already, so
+  // that PR only has to add the markup and its styling -- no JavaScript change needed.
+  // No-ops until #version-notice exists.
+  function setVersionNoticeVisible(visible) {
+    const notice = document.getElementById('version-notice');
+    if (notice) {
+      notice.hidden = !visible;
+    }
+  }
+
+  // Placeholder until the notice element ships: keeps a stale link observable, and lets
+  // the detection path be verified before any UI exists.
+  function reportVersionMismatch(linkVersion, currentVersion) {
+    console.warn(
+      `[pemm-assessment] This link was created with assessment version ${linkVersion}, ` +
+      `but the current question set is ${currentVersion}. ` +
+      `Results may not reflect the current model.`
+    );
+  }
+
+  // Show which question set and upstream model the page is running, so a screenshot or a
+  // shared result can be traced back to the content it was produced from.
+  function renderVersionFooter() {
+    const footer = document.getElementById('version-footer');
+    if (!footer) return;
+
+    const contentVersion = getContentVersion();
+    const modelVersion = questionsData?.metadata?.model_version || null;
+    const modelUrl = questionsData?.metadata?.model_url || null;
+
+    const contentValue = document.getElementById('content-version-value');
+    const modelValue = document.getElementById('model-version-value');
+    const modelGroup = document.getElementById('model-version-group');
+    const modelLink = document.getElementById('model-version-link');
+
+    if (contentValue) contentValue.textContent = contentVersion ?? '';
+    if (modelValue) modelValue.textContent = modelVersion ?? '';
+
+    // Without an href the anchor renders as plain text, so a content file that omits
+    // model_url still shows the model name -- it just is not clickable.
+    if (modelLink) {
+      if (modelUrl) {
+        modelLink.href = modelUrl;
+      } else {
+        modelLink.removeAttribute('href');
+      }
+    }
+
+    // Drop the model half rather than leaving a dangling label behind
+    if (modelGroup) modelGroup.hidden = !modelVersion;
+
+    // Nothing worth showing if the content file declares no version at all
+    footer.hidden = !contentVersion;
+  }
+
   // Update pagination button states (global scope)
   function updatePaginationControls() {
     const previous = document.getElementById('prev-btn');
@@ -109,6 +196,9 @@ let answerState = {};
         elem.innerHTML = data.metadata[key];
       }
     });
+
+    // Runs after the data-text pass so the labels are localized before values fill in
+    renderVersionFooter();
 
     // Store categories for pagination
     categoryPages = data.categories.sort((a, b) => a.order - b.order);
@@ -493,6 +583,13 @@ let answerState = {};
         newParams.set(key, answerState[key]);
       }
 
+      // These links are rebuilt from scratch, so the version stamp has to be re-applied
+      // or it would be dropped every time the user switches language.
+      const contentVersion = getContentVersion();
+      if (contentVersion && Object.keys(answerState).length) {
+        newParams.set(VERSION_PARAM, contentVersion);
+      }
+
       // Preserve current view if results are visible (so switching language stays on results)
       const resultsSection = document.getElementById('results-section');
       const isResultsVisible = resultsSection && resultsSection.style.display === 'block';
@@ -524,6 +621,13 @@ let answerState = {};
       params.set(key, answerState[key]);
     }
 
+    // Stamp the question-set version, but only once there are answers to qualify.
+    // A visitor who has not answered anything yet keeps a clean, unversioned URL.
+    const contentVersion = getContentVersion();
+    if (contentVersion && Object.keys(answerState).length) {
+      params.set(VERSION_PARAM, contentVersion);
+    }
+
     // Preserve current view state (results vs assessment)
     const resultsSection = document.getElementById('results-section');
     const isResultsVisible = resultsSection && resultsSection.style.display === 'block';
@@ -539,13 +643,14 @@ let answerState = {};
 
   function loadStateFromURL() {
     const params = new URLSearchParams(window.location.search);
+    const linkVersion = params.get(VERSION_PARAM);
 
     // Clear existing state
     answerState = {};
 
-    // Load all parameters into answerState (except 'lang')
+    // Every param that is not reserved is treated as an answer
     for (const [key, value] of params.entries()) {
-      if (key !== 'lang' && key !== 'view') {
+      if (!RESERVED_PARAMS.has(key)) {
         answerState[key] = value;
       }
     }
@@ -560,6 +665,20 @@ let answerState = {};
         radio.checked = true;
       }
     }
+
+    // Warn only when a shared link carried both answers and a version that no longer
+    // matches the current question set. Answers are never discarded.
+    const currentVersion = getContentVersion();
+    const mismatched =
+      Boolean(linkVersion) &&
+      Object.keys(answerState).length > 0 &&
+      isVersionMismatch(linkVersion, currentVersion);
+
+    if (mismatched) {
+      reportVersionMismatch(linkVersion, currentVersion);
+    }
+
+    setVersionNoticeVisible(mismatched);
 
     updateScores();
   }

--- a/assets/app.js
+++ b/assets/app.js
@@ -629,7 +629,10 @@ let answerState = {};
     });
   }
 
-  function saveStateToURL() {
+  // Answering a question rewrites the current history entry, so the back button is not
+  // consumed by twenty radio clicks. Moving between pages pushes a new entry instead, so
+  // back steps through the assessment the way the URL implies it should.
+  function saveStateToURL(createHistoryEntry = false) {
     const params = new URLSearchParams();
 
     // Preserve language parameter
@@ -664,10 +667,41 @@ let answerState = {};
     }
 
     const newURL = window.location.pathname + "?" + params.toString();
-    window.history.replaceState({}, "", newURL);
+
+    if (createHistoryEntry) {
+      window.history.pushState({}, "", newURL);
+    } else {
+      window.history.replaceState({}, "", newURL);
+    }
 
     updateLanguageSwitcher();
   }
+
+  // Back and forward move between pages without reloading the document, so the view has
+  // to be rebuilt from the URL by hand.
+  function applyStateFromURL() {
+    currentPage = readPageFromURL(totalPages);
+
+    // Answers first, so the freshly rendered page restores from current state rather
+    // than whatever was on screen before
+    loadStateFromURL();
+    renderCurrentPage();
+    updatePaginationControls();
+
+    const formSection = document.querySelector('.form-section');
+    const resultsSection = document.getElementById('results-section');
+    const wantsResults =
+      new URLSearchParams(window.location.search).get('view') === 'results';
+
+    if (wantsResults) {
+      showResults();
+    } else {
+      if (resultsSection) resultsSection.style.display = 'none';
+      if (formSection) formSection.style.display = 'block';
+    }
+  }
+
+  window.addEventListener('popstate', applyStateFromURL);
 
   function loadStateFromURL() {
     const params = new URLSearchParams(window.location.search);
@@ -871,9 +905,9 @@ window.nextPage = function () {
     currentPage++;
     renderCurrentPage();
     window.updatePaginationControls();
-    // Re-sync the URL now that currentPage has moved, since saveCurrentPageAnswers()
-    // wrote it using the page we just left
-    window.saveStateToURL();
+    // Push, not replace, so the page we just left stays in history for the back button.
+    // saveCurrentPageAnswers() already rewrote that entry with the answers on it.
+    window.saveStateToURL(true);
     // Scroll to top of page for better UX
     window.scrollTo(0, 0);
   }
@@ -886,9 +920,9 @@ window.previousPage = function () {
     currentPage--;
     renderCurrentPage();
     window.updatePaginationControls();
-    // Re-sync the URL now that currentPage has moved, since saveCurrentPageAnswers()
-    // wrote it using the page we just left
-    window.saveStateToURL();
+    // Push, not replace, so the page we just left stays in history for the back button.
+    // saveCurrentPageAnswers() already rewrote that entry with the answers on it.
+    window.saveStateToURL(true);
     // Scroll to top of page for better UX
     window.scrollTo(0, 0);
   }
@@ -897,8 +931,9 @@ window.previousPage = function () {
 window.submitAssessment = function () {
   saveCurrentPageAnswers();
   showResults();
-  // Persist results view in the URL so it can be restored or preserved when changing language
-  window.saveStateToURL();
+  // Persist results view in the URL so it can be restored or preserved when changing
+  // language, and push it so back returns to the assessment rather than leaving the site
+  window.saveStateToURL(true);
   // Scroll to top to show results section
   window.scrollTo(0, 0);
 };

--- a/assets/app.js
+++ b/assets/app.js
@@ -47,9 +47,28 @@ let answerState = {};
   // Query-string key holding the content version a shareable link was built against.
   const VERSION_PARAM = 'v';
 
+  // Query-string key holding which page of the assessment is open.
+  const PAGE_PARAM = 'page';
+
   // Params that are not answers. Anything else in the query string is treated as one,
   // so every non-answer param must be listed here.
-  const RESERVED_PARAMS = new Set(['lang', 'view', VERSION_PARAM]);
+  const RESERVED_PARAMS = new Set(['lang', 'view', VERSION_PARAM, PAGE_PARAM]);
+
+  // Page position is 1-based in the URL so it matches the "Page 3 of 5" indicator.
+  // Switching language is a full navigation, so without this the reader is sent back
+  // to the first page every time.
+  function readPageFromURL(pageCount) {
+    const page = Number.parseInt(
+      new URLSearchParams(window.location.search).get(PAGE_PARAM),
+      10
+    );
+
+    if (!Number.isInteger(page) || pageCount < 1) return 0;
+
+    // Clamp rather than reject: a link shared before a category was added or removed
+    // should still land somewhere sensible.
+    return Math.min(Math.max(page - 1, 0), pageCount - 1);
+  }
 
   // Version of the question set currently loaded, or null if data failed to load.
   function getContentVersion() {
@@ -203,7 +222,7 @@ let answerState = {};
     // Store categories for pagination
     categoryPages = data.categories.sort((a, b) => a.order - b.order);
     totalPages = categoryPages.length;
-    currentPage = 0;
+    currentPage = readPageFromURL(totalPages);
 
     // Initialize pagination
     renderCurrentPage();
@@ -583,11 +602,15 @@ let answerState = {};
         newParams.set(key, answerState[key]);
       }
 
-      // These links are rebuilt from scratch, so the version stamp has to be re-applied
-      // or it would be dropped every time the user switches language.
+      // These links are rebuilt from scratch, so the version stamp and page position have
+      // to be re-applied or they would be dropped every time the user switches language.
       const contentVersion = getContentVersion();
       if (contentVersion && Object.keys(answerState).length) {
         newParams.set(VERSION_PARAM, contentVersion);
+      }
+
+      if (currentPage > 0) {
+        newParams.set(PAGE_PARAM, String(currentPage + 1));
       }
 
       // Preserve current view if results are visible (so switching language stays on results)
@@ -626,6 +649,11 @@ let answerState = {};
     const contentVersion = getContentVersion();
     if (contentVersion && Object.keys(answerState).length) {
       params.set(VERSION_PARAM, contentVersion);
+    }
+
+    // Only past the first page, so the entry URL stays clean
+    if (currentPage > 0) {
+      params.set(PAGE_PARAM, String(currentPage + 1));
     }
 
     // Preserve current view state (results vs assessment)
@@ -832,10 +860,14 @@ function restoreCurrentPageAnswers() {
 // Global pagination functions (accessible from HTML)
 window.nextPage = function () {
   if (currentPage < totalPages - 1) {
+    // Answers first: this reads the radios that are about to be replaced
     saveCurrentPageAnswers();
     currentPage++;
     renderCurrentPage();
     window.updatePaginationControls();
+    // Re-sync the URL now that currentPage has moved, since saveCurrentPageAnswers()
+    // wrote it using the page we just left
+    window.saveStateToURL();
     // Scroll to top of page for better UX
     window.scrollTo(0, 0);
   }
@@ -843,10 +875,14 @@ window.nextPage = function () {
 
 window.previousPage = function () {
   if (currentPage > 0) {
+    // Answers first: this reads the radios that are about to be replaced
     saveCurrentPageAnswers();
     currentPage--;
     renderCurrentPage();
     window.updatePaginationControls();
+    // Re-sync the URL now that currentPage has moved, since saveCurrentPageAnswers()
+    // wrote it using the page we just left
+    window.saveStateToURL();
     // Scroll to top of page for better UX
     window.scrollTo(0, 0);
   }

--- a/assets/app.js
+++ b/assets/app.js
@@ -708,6 +708,12 @@ let answerState = {};
 
     setVersionNoticeVisible(mismatched);
 
+    // Answers that arrive from the URL -- a shared link, a bookmark, a refresh, or the
+    // browser back button -- still have to reach the language links, which are otherwise
+    // only rebuilt when saveStateToURL() runs. Without this, switching language after
+    // any of those discards the answers.
+    updateLanguageSwitcher();
+
     updateScores();
   }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -9,6 +9,7 @@
     /* Text Colors */
     --text-primary: #000;
     --text-heading: #000;
+    --text-muted: #595959;
 
     /* Background Colors */
     --bg-gradient-start: #0175E4;
@@ -438,4 +439,36 @@ label:has(input[type="radio"]:checked) {
 
 .heat_4 {
     background-color: var(--heat-4);
+}
+
+.version-footer {
+    max-width: var(--container-max-width);
+    margin: 0 auto;
+    padding-block-end: var(--spacing-xl);
+    text-align: center;
+    font-size: 14px;
+    color: var(--text-muted);
+}
+
+/* Keep the hidden attribute effective regardless of any display rule above */
+.version-footer[hidden],
+.version-footer [hidden] {
+    display: none;
+}
+
+.version-separator {
+    padding-inline: var(--spacing-xs);
+}
+
+/* Keep the whitepaper link legible but subdued -- the site-wide anchor colour is too
+   loud for a footer note */
+.version-footer a {
+    color: inherit;
+    font-weight: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.version-footer a:hover {
+    color: var(--primary-color);
 }

--- a/data/quarantine/questions-de.yaml
+++ b/data/quarantine/questions-de.yaml
@@ -10,7 +10,7 @@ metadata:
   # Canonical URL for that model version, carrying campaign tags so referrals from
   # this assessment are attributable. Kept beside model_version so the two cannot
   # drift apart when the upstream model is revised.
-  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
+  model_url: "https://cloudnativeplatforms.com/de/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: "Platform Engineering Reifegrad-Modell Bewertung"
   language: "de"
   language_native: "Deutsch"
@@ -26,7 +26,7 @@ metadata:
     die Herausforderungen zu orientieren, denen sie begegnen könnten, und Chancen aufzuzeigen, die sie anstreben 
     können.</p>
     <p>Diese Bewertung basiert auf dem 
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF Platform Engineering Reifegrad-Modell</a>, 
+    <a href="https://cloudnativeplatforms.com/de/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF Platform Engineering Reifegrad-Modell</a>, 
     das fünf Schlüsselaspekte bewertet: <strong>Investition</strong>, <strong>Adoption</strong>, <strong>Schnittstellen</strong>, 
     <strong>Betrieb</strong> und <strong>Messung</strong>.</p>
   results_title: "Bewertungsergebnisse"

--- a/data/quarantine/questions-de.yaml
+++ b/data/quarantine/questions-de.yaml
@@ -7,6 +7,10 @@ metadata:
   content_version: "0.9.0"
   # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
   model_version: "1.0"
+  # Canonical URL for that model version, carrying campaign tags so referrals from
+  # this assessment are attributable. Kept beside model_version so the two cannot
+  # drift apart when the upstream model is revised.
+  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: "Platform Engineering Reifegrad-Modell Bewertung"
   language: "de"
   language_native: "Deutsch"
@@ -22,7 +26,7 @@ metadata:
     die Herausforderungen zu orientieren, denen sie begegnen könnten, und Chancen aufzuzeigen, die sie anstreben 
     können.</p>
     <p>Diese Bewertung basiert auf dem 
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF Platform Engineering Reifegrad-Modell</a>, 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF Platform Engineering Reifegrad-Modell</a>, 
     das fünf Schlüsselaspekte bewertet: <strong>Investition</strong>, <strong>Adoption</strong>, <strong>Schnittstellen</strong>, 
     <strong>Betrieb</strong> und <strong>Messung</strong>.</p>
   results_title: "Bewertungsergebnisse"

--- a/data/quarantine/questions-de.yaml
+++ b/data/quarantine/questions-de.yaml
@@ -2,6 +2,11 @@
 # This file contains all questions, answers, and metadata for the German version
 
 metadata:
+  # Quarantined: structurally at parity with questions-en.yaml, but not yet published.
+  # Version of the question set defined in this file. See VERSIONING.md for bump rules.
+  content_version: "0.9.0"
+  # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
+  model_version: "1.0"
   title: "Platform Engineering Reifegrad-Modell Bewertung"
   language: "de"
   language_native: "Deutsch"

--- a/data/quarantine/questions-es.yaml
+++ b/data/quarantine/questions-es.yaml
@@ -11,7 +11,7 @@ metadata:
   # Canonical URL for that model version, carrying campaign tags so referrals from
   # this assessment are attributable. Kept beside model_version so the two cannot
   # drift apart when the upstream model is revised.
-  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
+  model_url: "https://cloudnativeplatforms.com/es/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: "Evaluación del Modelo de Madurez de Ingeniería de Plataforma"
   language: "es"
   language_native: "Español"
@@ -26,7 +26,7 @@ metadata:
     y observaciones en un modelo de madurez progresivo, buscamos orientar a los equipos de plataforma hacia los 
     desafíos que pueden enfrentar y las oportunidades que pueden perseguir.</p>
     <p>Esta evaluación se basa en el 
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">Modelo de Madurez de 
+    <a href="https://cloudnativeplatforms.com/es/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">Modelo de Madurez de 
     Ingeniería de Plataforma de CNCF</a>, 
     que evalúa cinco aspectos clave: <strong>Inversión</strong>, <strong>Adopción</strong>, <strong>Interfaces</strong>, 
     <strong>Operaciones</strong> y <strong>Medición</strong>.</p>

--- a/data/quarantine/questions-es.yaml
+++ b/data/quarantine/questions-es.yaml
@@ -2,6 +2,12 @@
 # This file contains all questions, answers, and metadata for the Spanish version
 
 metadata:
+  # Quarantined: incomplete — only 15 of the 20 questions in questions-en.yaml are present.
+  # 0.0.0 means "not aligned to any released question set"; do not publish until it reaches
+  # full structural parity, then set content_version to match questions-en.yaml.
+  content_version: "0.0.0"
+  # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
+  model_version: "1.0"
   title: "Evaluación del Modelo de Madurez de Ingeniería de Plataforma"
   language: "es"
   language_native: "Español"

--- a/data/quarantine/questions-es.yaml
+++ b/data/quarantine/questions-es.yaml
@@ -8,6 +8,10 @@ metadata:
   content_version: "0.0.0"
   # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
   model_version: "1.0"
+  # Canonical URL for that model version, carrying campaign tags so referrals from
+  # this assessment are attributable. Kept beside model_version so the two cannot
+  # drift apart when the upstream model is revised.
+  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: "Evaluación del Modelo de Madurez de Ingeniería de Plataforma"
   language: "es"
   language_native: "Español"
@@ -22,7 +26,7 @@ metadata:
     y observaciones en un modelo de madurez progresivo, buscamos orientar a los equipos de plataforma hacia los 
     desafíos que pueden enfrentar y las oportunidades que pueden perseguir.</p>
     <p>Esta evaluación se basa en el 
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">Modelo de Madurez de 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">Modelo de Madurez de 
     Ingeniería de Plataforma de CNCF</a>, 
     que evalúa cinco aspectos clave: <strong>Inversión</strong>, <strong>Adopción</strong>, <strong>Interfaces</strong>, 
     <strong>Operaciones</strong> y <strong>Medición</strong>.</p>

--- a/data/questions-en.yaml
+++ b/data/questions-en.yaml
@@ -1,6 +1,10 @@
 # Platform Engineering Maturity Model Assessment
 
 metadata:
+  # Version of the question set defined in this file. See VERSIONING.md for bump rules.
+  content_version: "0.9.0"
+  # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
+  model_version: "1.0"
   title: Platform Engineering Maturity Model Assessment
   language: en
   language_native: English
@@ -29,6 +33,11 @@ metadata:
   next_button_text: Next
   submit_button_text: Submit assessment
   back_to_assessment: Return to assessment
+  version_label: Assessment version
+  model_version_label: Based on CNCF Platform Engineering Maturity Model
+  version_mismatch_notice: >
+    This link was created with an earlier version of the assessment. The questions have
+    changed since then, so these results may not reflect the current model.
 
 categories:
   - id: investment

--- a/data/questions-en.yaml
+++ b/data/questions-en.yaml
@@ -5,6 +5,10 @@ metadata:
   content_version: "0.9.0"
   # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
   model_version: "1.0"
+  # Canonical URL for that model version, carrying campaign tags so referrals from
+  # this assessment are attributable. Kept beside model_version so the two cannot
+  # drift apart when the upstream model is revised.
+  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: Platform Engineering Maturity Model Assessment
   language: en
   language_native: English
@@ -17,7 +21,7 @@ metadata:
     for identifying opportunities for improvement in any organization. By organizing patterns and observations into a 
     progressive maturity model, we aim to orient platform teams to the challenges they may face and opportunities to aim for.</p>
     <p>This assessment is based on the 
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF Platform Engineering Maturity Model</a>, 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF Platform Engineering Maturity Model</a>, 
     which evaluates five key aspects: <strong>Investment</strong>, <strong>Adoption</strong>, <strong>Interfaces</strong>, <strong>Operations</strong>, 
     nd <strong>Measurement</strong>.</p>
   results_title: Assessment Results

--- a/data/questions-ja.yaml
+++ b/data/questions-ja.yaml
@@ -1,6 +1,14 @@
 # Platform Engineering Maturity Model Assessment
 
 metadata:
+  # Version of the question set defined in this file. See VERSIONING.md for bump rules.
+  content_version: "0.9.0"
+  # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
+  model_version: "1.0"
+  # Canonical URL for that model version, carrying campaign tags so referrals from
+  # this assessment are attributable. Kept beside model_version so the two cannot
+  # drift apart when the upstream model is revised. Japanese localisation of the whitepaper.
+  model_url: "https://cloudnativeplatforms.com/ja/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: プラットフォームエンジニアリング成熟度モデル アセスメント
   language: ja
   language_native: 日本語
@@ -9,7 +17,7 @@ metadata:
     <p><span class="highlight">プラットフォームエンジニアリング</span>とは、開発者やユーザーにコンピューティングプラットフォームを計画・提供するための実践手法です。人、プロセス、ポリシー、テクノロジーといった構成要素を整備するだけでなく、その目的であるビジネス成果を達成することまでをスコープに入れています。</p>
     <p><span class="highlight">プラットフォームエンジニアリング成熟度モデル</span>は、あらゆる組織が現状を振り返り、改善すべきポイントを洗い出すためのフレームワークを提供します。パターンや観察結果を段階的な成熟度モデルに整理することで、プラットフォームチームが直面しうる課題を予測し、次に目指すべき姿への道しるべとなることを目的としています。</p>
     <p>このアセスメントは
-    <a href="https://cloudnativeplatforms.com/ja/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF プラットフォームエンジニアリング成熟度モデル</a> に基づいており、
+    <a href="https://cloudnativeplatforms.com/ja/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF プラットフォームエンジニアリング成熟度モデル</a> に基づいており、
     <strong>投資</strong>、<strong>採用</strong>、<strong>インターフェース</strong>、<strong>戦略</strong>、<strong>計測</strong>の5つの重要な側面を評価します。</p>
   results_title: アセスメント結果
   feedback_message: >
@@ -24,6 +32,10 @@ metadata:
   next_button_text: 次へ
   submit_button_text: アセスメントの結果をみる
   back_to_assessment: アセスメントに戻る
+  version_label: アセスメントバージョン
+  model_version_label: 準拠する CNCF プラットフォームエンジニアリング成熟度モデル
+  version_mismatch_notice: >
+    このリンクは以前のバージョンのアセスメントで作成されました。その後設問が変更されているため、この結果は現在のモデルを反映していない可能性があります。
 
 categories:
   - id: investment

--- a/data/questions-pt.yaml
+++ b/data/questions-pt.yaml
@@ -1,6 +1,10 @@
 # Platform Engineering Maturity Model Assessment
 
 metadata:
+  # Version of the question set defined in this file. See VERSIONING.md for bump rules.
+  content_version: "0.9.0"
+  # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
+  model_version: "1.0"
   title: Avaliação do Modelo de Maturidade em Engenharia de Plataforma
   language: pt
   language_native: Português
@@ -32,6 +36,11 @@ metadata:
   submit_button_text: Enviar avaliação
   back_to_assessment: Voltar para a avaliação
   page_indicator_text: "Página {current} de {total}"
+  version_label: Versão da avaliação
+  model_version_label: Baseado no Modelo de Maturidade em Engenharia de Plataforma da CNCF
+  version_mismatch_notice: >
+    Este link foi criado com uma versão anterior da avaliação. As perguntas mudaram desde
+    então, portanto estes resultados podem não refletir o modelo atual.
 
 categories:
   - id: investment

--- a/data/questions-pt.yaml
+++ b/data/questions-pt.yaml
@@ -5,6 +5,10 @@ metadata:
   content_version: "0.9.0"
   # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
   model_version: "1.0"
+  # Canonical URL for that model version, carrying campaign tags so referrals from
+  # this assessment are attributable. Kept beside model_version so the two cannot
+  # drift apart when the upstream model is revised.
+  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: Avaliação do Modelo de Maturidade em Engenharia de Plataforma
   language: pt
   language_native: Português
@@ -17,7 +21,7 @@ metadata:
     oportunidades de melhoria em qualquer organização. Ao organizar padrões e observações em um modelo de maturidade progressivo, nosso objetivo é
     orientar as equipes de plataforma sobre os desafios que podem enfrentar e as oportunidades a serem buscadas.</p>
     <p>Esta avaliação é baseada no 
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">Modelo de Maturidade em Engenharia de Plataforma da CNCF</a>,
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">Modelo de Maturidade em Engenharia de Plataforma da CNCF</a>,
     que avalia cinco aspectos-chave: <strong>Investimento</strong>, <strong>Adoção</strong>, <strong>Interfaces de Usuário</strong>,
     <strong>Modelo Operacional</strong> e <strong>Métricas e Indicadores</strong>.</p><p>Estamos em busca de feedback sobre esta avaliação piloto, 
     então, por favor,

--- a/data/questions-zh.yaml
+++ b/data/questions-zh.yaml
@@ -1,6 +1,10 @@
 # Platform Engineering Maturity Model Assessment
 
 metadata:
+  # Version of the question set defined in this file. See VERSIONING.md for bump rules.
+  content_version: "0.9.0"
+  # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
+  model_version: "1.0"
   title: 平台工程成熟度模型评估
   language: zh
   language_native: 中文
@@ -25,6 +29,10 @@ metadata:
   next_button_text: 下一页
   submit_button_text: 提交评估
   back_to_assessment: 返回评估
+  version_label: 评估版本
+  model_version_label: 基于 CNCF 平台工程成熟度模型
+  version_mismatch_notice: >
+    此链接是使用旧版本的评估创建的。此后问题已发生变化，因此这些结果可能无法反映当前模型。
 
 categories:
   - id: investment

--- a/data/questions-zh.yaml
+++ b/data/questions-zh.yaml
@@ -8,7 +8,7 @@ metadata:
   # Canonical URL for that model version, carrying campaign tags so referrals from
   # this assessment are attributable. Kept beside model_version so the two cannot
   # drift apart when the upstream model is revised.
-  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
+  model_url: "https://cloudnativeplatforms.com/zh/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: 平台工程成熟度模型评估
   language: zh
   language_native: 中文
@@ -18,7 +18,7 @@ metadata:
     <p>这个<span class="highlight">平台工程成熟度模型</span>为反思和识别任何组织的改进机会提供了一个框架。通过将模式和观察结果组织成渐进式成熟度模型，
     我们旨在为平台团队指明他们可能面临的挑战和可以追求的机会。</p>
     <p>此评估基于
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF平台工程成熟度模型</a>, 
+    <a href="https://cloudnativeplatforms.com/zh/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF平台工程成熟度模型</a>, 
     该模型评估五个关键方面：<strong>投入</strong>、<strong>采用</strong>、<strong>接口</strong>、<strong>运营</strong>和<strong>度量</strong>。</p>
     <p>我们正在征询对此次试点评估的反馈意见，请与我们
   results_title: 评估结果

--- a/data/questions-zh.yaml
+++ b/data/questions-zh.yaml
@@ -5,6 +5,10 @@ metadata:
   content_version: "0.9.0"
   # Version of the upstream CNCF Platform Engineering Maturity Model these questions follow.
   model_version: "1.0"
+  # Canonical URL for that model version, carrying campaign tags so referrals from
+  # this assessment are attributable. Kept beside model_version so the two cannot
+  # drift apart when the upstream model is revised.
+  model_url: "https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&utm_medium=referral&utm_campaign=platform-maturity-assessment&utm_content=version-footer"
   title: 平台工程成熟度模型评估
   language: zh
   language_native: 中文
@@ -14,7 +18,7 @@ metadata:
     <p>这个<span class="highlight">平台工程成熟度模型</span>为反思和识别任何组织的改进机会提供了一个框架。通过将模式和观察结果组织成渐进式成熟度模型，
     我们旨在为平台团队指明他们可能面临的挑战和可以追求的机会。</p>
     <p>此评估基于
-    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/" target="_blank">CNCF平台工程成熟度模型</a>, 
+    <a href="https://cloudnativeplatforms.com/whitepapers/platform-eng-maturity-model/v1/?utm_source=pemm-assessment&amp;utm_medium=referral&amp;utm_campaign=platform-maturity-assessment&amp;utm_content=intro" target="_blank">CNCF平台工程成熟度模型</a>, 
     该模型评估五个关键方面：<strong>投入</strong>、<strong>采用</strong>、<strong>接口</strong>、<strong>运营</strong>和<strong>度量</strong>。</p>
     <p>我们正在征询对此次试点评估的反馈意见，请与我们
   results_title: 评估结果

--- a/index.html
+++ b/index.html
@@ -69,6 +69,18 @@
       </article>
     </main>
 
+    <footer class="version-footer" id="version-footer" hidden>
+      <span data-text="version_label">Assessment version</span>
+      <span id="content-version-value"></span>
+      <span id="model-version-group">
+        <span class="version-separator">·</span>
+        <a id="model-version-link" target="_blank" rel="noopener noreferrer">
+          <span data-text="model_version_label">Based on CNCF Platform Engineering Maturity Model</span>
+          <span id="model-version-value"></span>
+        </a>
+      </span>
+    </footer>
+
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
     <script src="./assets/app.js"></script>
   </body>

--- a/scripts/validate_content.py
+++ b/scripts/validate_content.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Validate the assessment content files in data/.
+
+Checks that every language file stays structurally identical to the English source,
+that version metadata is present and well formed, and that a change to the English
+question set is accompanied by a content_version bump.
+
+Why structural parity matters: field_name values and option values are serialized
+straight into shareable result URLs, so they are a public contract. If one language
+renames a field or drops an option, links shared from that language stop meaning the
+same thing as links shared from another.
+
+Usage:
+    python3 scripts/validate_content.py                  # structural checks only
+    python3 scripts/validate_content.py --base origin/main   # also gate version bumps
+
+Exits non-zero if any blocking check fails. Files under data/quarantine/ are reported
+on but never block, since they are known to be incomplete.
+"""
+
+import argparse
+import glob
+import html
+import os
+import re
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required: pip install pyyaml")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SOURCE_FILE = "data/questions-en.yaml"
+PUBLISHED_GLOB = "data/questions-*.yaml"
+QUARANTINE_GLOB = "data/quarantine/questions-*.yaml"
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+WHITEPAPER_HOST = "cloudnativeplatforms.com"
+
+errors = []
+warnings = []
+
+
+def error(where, message):
+    errors.append(f"{where}: {message}")
+
+
+def warn(where, message):
+    warnings.append(f"{where}: {message}")
+
+
+def load(path):
+    """Parse a content file, recording a blocking error if it is not valid YAML."""
+    try:
+        with open(os.path.join(REPO_ROOT, path), encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+    except (yaml.YAMLError, OSError) as exc:
+        error(path, f"could not be parsed: {exc}")
+        return None
+
+
+def structure(doc):
+    """Reduce a document to the parts that form the shareable-URL contract."""
+    return [
+        {
+            "id": category.get("id"),
+            "order": category.get("order"),
+            "questions": [
+                {
+                    "id": question.get("id"),
+                    "field_name": question.get("field_name"),
+                    "values": [opt.get("value") for opt in (question.get("options") or [])],
+                }
+                for question in (category.get("questions") or [])
+            ],
+        }
+        for category in (doc.get("categories") or [])
+    ]
+
+
+def base_url(url):
+    parts = urlparse(url)
+    return f"{parts.scheme}://{parts.netloc}{parts.path}"
+
+
+def check_metadata(path, doc, report, source_model=None):
+    """Version fields must be present, well formed, and internally consistent."""
+    metadata = (doc or {}).get("metadata") or {}
+
+    for field in ("content_version", "model_version", "model_url"):
+        if not metadata.get(field):
+            report(path, f"metadata.{field} is missing")
+
+    version = metadata.get("content_version")
+    if version and not SEMVER.match(str(version)):
+        report(path, f"content_version {version!r} is not major.minor.patch")
+
+    # Every language must describe the same upstream model release. model_url may differ --
+    # a translation is encouraged to link its own localisation of the whitepaper -- but the
+    # release it points at has to be the same one.
+    model = metadata.get("model_version")
+    if source_model and model and model != source_model:
+        report(
+            path,
+            f"model_version {model!r} does not match the source {source_model!r}; every "
+            f"language must track the same upstream model release",
+        )
+
+    # The intro prose links to the whitepaper, and model_url points at the same document.
+    # They live in different places and are easy to update independently, so pin them
+    # together here rather than discovering the mismatch in production.
+    model_url = metadata.get("model_url")
+    intro = metadata.get("intro") or ""
+    intro_links = [
+        html.unescape(href)
+        for href in re.findall(r'href="([^"]+)"', intro)
+        if WHITEPAPER_HOST in href
+    ]
+
+    if not intro_links:
+        warn(path, "intro does not link to the maturity model whitepaper")
+    elif model_url:
+        for link in intro_links:
+            if base_url(link) != base_url(model_url):
+                report(
+                    path,
+                    f"intro links to {base_url(link)} but model_url points at "
+                    f"{base_url(model_url)}",
+                )
+
+    return metadata
+
+
+def check_parity(path, doc, source_structure, report):
+    """Compare a translation against the English source, field by field."""
+    found = structure(doc)
+
+    source_ids = [c["id"] for c in source_structure]
+    found_ids = [c["id"] for c in found]
+    if source_ids != found_ids:
+        report(path, f"category ids differ: expected {source_ids}, found {found_ids}")
+        return
+
+    for expected, actual in zip(source_structure, found):
+        where = f"{path} [{expected['id']}]"
+
+        if expected["order"] != actual["order"]:
+            report(where, f"order differs: expected {expected['order']}, found {actual['order']}")
+
+        expected_fields = [q["field_name"] for q in expected["questions"]]
+        actual_fields = [q["field_name"] for q in actual["questions"]]
+        if expected_fields != actual_fields:
+            missing = [f for f in expected_fields if f not in actual_fields]
+            extra = [f for f in actual_fields if f not in expected_fields]
+            detail = []
+            if missing:
+                detail.append(f"missing {missing}")
+            if extra:
+                detail.append(f"unexpected {extra}")
+            if not detail:
+                detail.append(f"order differs: expected {expected_fields}, found {actual_fields}")
+            report(where, "field_name mismatch: " + "; ".join(detail))
+            continue
+
+        for exp_q, act_q in zip(expected["questions"], actual["questions"]):
+            if exp_q["id"] != act_q["id"]:
+                report(
+                    f"{where} {exp_q['field_name']}",
+                    f"question id differs: expected {exp_q['id']}, found {act_q['id']}",
+                )
+            if exp_q["values"] != act_q["values"]:
+                report(
+                    f"{where} {exp_q['field_name']}",
+                    f"option values differ: expected {exp_q['values']}, found {act_q['values']}",
+                )
+
+
+def git(*args):
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def check_version_bump(base):
+    """A change to the English question set must come with a content_version bump.
+
+    Only questions-en.yaml is gated. It is the source of truth, so a translation-only
+    fix does not redefine the question set and needs no bump -- the staleness warning
+    below is what tracks translations catching up.
+    """
+    changed = git("diff", "--name-only", f"{base}...HEAD", "--", SOURCE_FILE)
+    if changed is None:
+        warn("version gate", f"could not diff against {base}; skipping bump check")
+        return
+    if not changed:
+        return
+
+    previous = git("show", f"{base}:{SOURCE_FILE}")
+    if previous is None:
+        return  # new file, nothing to compare against
+
+    try:
+        before = (yaml.safe_load(previous) or {}).get("metadata", {}).get("content_version")
+    except yaml.YAMLError:
+        return
+
+    current = (load(SOURCE_FILE) or {}).get("metadata", {}).get("content_version")
+
+    if before and before == current:
+        error(
+            SOURCE_FILE,
+            f"content changed but content_version is still {current!r}. "
+            f"Bump it per the rules in VERSIONING.md",
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="git ref to diff against for the version-bump gate")
+    args = parser.parse_args()
+
+    source = load(SOURCE_FILE)
+    if source is None:
+        print(f"✗ {SOURCE_FILE} could not be read; cannot validate anything else")
+        return 1
+
+    source_structure = structure(source)
+    source_version = (source.get("metadata") or {}).get("content_version")
+    source_model = (source.get("metadata") or {}).get("model_version")
+
+    published = sorted(
+        p for p in glob.glob(os.path.join(REPO_ROOT, PUBLISHED_GLOB))
+    )
+    print(f"Source: {SOURCE_FILE} (content_version {source_version})")
+    print(
+        f"Question set: {len(source_structure)} categories, "
+        f"{sum(len(c['questions']) for c in source_structure)} questions\n"
+    )
+
+    print("Published languages (blocking):")
+    for path in published:
+        rel = os.path.relpath(path, REPO_ROOT)
+        doc = load(rel)
+        if doc is None:
+            continue
+
+        metadata = check_metadata(rel, doc, error, source_model)
+        if rel != SOURCE_FILE:
+            check_parity(rel, doc, source_structure, error)
+
+            version = metadata.get("content_version")
+            if version and source_version and version != source_version:
+                warn(
+                    rel,
+                    f"content_version {version} is behind the source {source_version}; "
+                    f"translation may be out of date",
+                )
+        print(f"  - {rel} ({metadata.get('content_version', '?')})")
+
+    print("\nQuarantined (report only, never blocks):")
+    for path in sorted(glob.glob(os.path.join(REPO_ROOT, QUARANTINE_GLOB))):
+        rel = os.path.relpath(path, REPO_ROOT)
+        doc = load(rel)
+        if doc is None:
+            continue
+        before = len(warnings)
+        check_metadata(rel, doc, warn, source_model)
+        check_parity(rel, doc, source_structure, warn)
+        status = "not at parity" if len(warnings) > before else "at parity"
+        print(f"  - {rel} ({(doc.get('metadata') or {}).get('content_version', '?')}) - {status}")
+
+    if args.base:
+        print(f"\nVersion gate: diffing {SOURCE_FILE} against {args.base}")
+        check_version_bump(args.base)
+
+    if warnings:
+        print(f"\n⚠ {len(warnings)} warning(s):")
+        for item in warnings:
+            print(f"  ⚠ {item}")
+
+    if errors:
+        print(f"\n✗ {len(errors)} error(s):")
+        for item in errors:
+            print(f"  ✗ {item}")
+        return 1
+
+    print("\n✓ All blocking checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This fixes some issues and adds validation workflows, in addition to cleaning up the repo to help new contributors.

### Added

- Version metadata (`content_version`, `model_version`, `model_url`) in every content file.
- Version stamp on shareable result URLs, so a link records which question set produced it.
- Detection of links built against an older question set.
- Page footer showing the assessment version and a link to the maturity model whitepaper.
- Content validation in CI.
- [VERSIONING.md](VERSIONING.md) describing the versioning scheme and release process.
- This changelog.

### Changed

- Whitepaper links point at the versioned `/v1/` URL, localised per language where available.
- Whitepaper links carry campaign parameters.

### Fixed

- Answers were lost when switching language after arriving from a URL that already contained them.
- Switching language reset the assessment to the first page.
- The browser back button did not step between assessment pages.
- `README.md` listed the wrong option scale and language set.